### PR TITLE
Add platform sdk 5.1.0 release notes

### DIFF
--- a/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
@@ -19,9 +19,7 @@ If you are debugging in the cloud, be aware of other app end-users. Breakpoints 
 {{% /alert %}}
 
 {{% alert type="warning" %}}
-**It is currently not possible to debug Nanoflows remotely.**
-
-If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled, as it is not currently possible to debug nanoflows remotely.
+**It is currently not possible to debug nanoflows remotely.** If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled.
 {{% /alert %}}
 
 **This how-to will teach you how to do the following:**

--- a/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
+++ b/content/howto/monitoring-troubleshooting/debug-microflows-remotely.md
@@ -18,6 +18,12 @@ These instructions are for apps running in Mendix Cloud v4. If you are running a
 If you are debugging in the cloud, be aware of other app end-users. Breakpoints in the debugger will pause processes for all users of the app in this environment.
 {{% /alert %}}
 
+{{% alert type="warning" %}}
+**It is currently not possible to debug Nanoflows remotely.**
+
+If you are debugging in the cloud, any breakpoint added to a nanoflow will be disabled, as it is not currently possible to debug nanoflows remotely.
+{{% /alert %}}
+
 **This how-to will teach you how to do the following:**
 
 * Connect the debugger in Studio Pro to your Mendix Cloud v4 environment

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -10,7 +10,7 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 ## 2022
 
-## March 11th, 2022
+### March 11th, 2022
 
 #### Fixes
 

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -14,7 +14,7 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 #### Fixes
 
-* We fixed Update/Switch button's functionality for Consumed OData Services
+* We fixed the **Update/Switch** button's functionality for consumed OData services.
 
 ### March 10th, 2022
 

--- a/content/releasenotes/data-hub/index.md
+++ b/content/releasenotes/data-hub/index.md
@@ -10,6 +10,12 @@ These release notes cover changes made to the [Mendix Data Hub](/data-hub/).
 
 ## 2022
 
+## March 11th, 2022
+
+#### Fixes
+
+* We fixed Update/Switch button's functionality for Consumed OData Services
+
 ### March 10th, 2022
 
 #### Improvements 

--- a/content/releasenotes/sdk/platform-sdk.md
+++ b/content/releasenotes/sdk/platform-sdk.md
@@ -7,6 +7,12 @@ menu_order: 2
 
 These are the [Mendix Platform SDK](/apidocs-mxsdk/mxsdk/) release notes, including all minor versions and patches.
 
+## 5.1.0
+
+**Release date: March 11th, 2022**
+
+* It is no longer mandatory to include the `branches/` prefix for SVN branch names that are not `trunk`.
+
 ## 5.0.0
 
 **Release date: February 23rd, 2022**

--- a/themes/mendix/layouts/partials/frontpage/featured.html
+++ b/themes/mendix/layouts/partials/frontpage/featured.html
@@ -9,7 +9,7 @@
 	<li><a href="/releasenotes/mobile/nt-6-rn">Native Template 6.2.12</a> – Jan 25th, 2022</li>	
 	<li><a href="/releasenotes/developer-portal">Developer Portal</a> – Mar 10th, 2022</li>
 	<li><a href="/releasenotes/developer-portal/deployment">Deployment</a> – Mar 10th, 2022</li>
-	<li><a href="/releasenotes/data-hub">Data Hub</a> – Mar 10th, 2022</li>
+	<li><a href="/releasenotes/data-hub">Data Hub</a> – Mar 11th, 2022</li>
 	<li><a href="/releasenotes/app-store">Marketplace</a> – Feb 24th, 2022</li>
 	<li><a href="/releasenotes/sdk/model-sdk-4">Model SDK 4.60.0</a> – Feb 16th, 2022</li>
 	<li><a href="/releasenotes/sdk/metamodel-9.11">Metamodel 9.11.0</a> – Feb 16th, 2022</li>


### PR DESCRIPTION
It is no longer mandatory to include the `branches/` prefix for SVN branch names that are not `trunk` in Repository Service endpoints. The new platform SDK version does not enforce the prefix check on the client side.
